### PR TITLE
Non discovery methods decorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     sudo: required
     dist: xenial
   - python: 3.6
-    env: TOX_ENV=flake8
-  - python: 3.6
     env: TOX_ENV=coverage
   - python: 3.6
     env: TOX_ENV=docs

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -232,7 +232,7 @@ a setup method with the word 'it' in the name.
 Contexts provides a built-in plugin which defines a set of decorators for overriding the way an object is named:
 
 * ``@examples`` to mark examples methods
-* ``@method`` to mark methods that are not involved in test discovery
+* ``@ignored`` to mark methods that are not involved in test definition
 * ``@setup`` to mark setup methods
 * ``@action`` to mark action methods
 * ``@assertion`` to mark assertion methods

--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -231,6 +231,8 @@ a setup method with the word 'it' in the name.
 
 Contexts provides a built-in plugin which defines a set of decorators for overriding the way an object is named:
 
+* ``@examples`` to mark examples methods
+* ``@method`` to mark methods that are not involved in test discovery
 * ``@setup`` to mark setup methods
 * ``@action`` to mark action methods
 * ``@assertion`` to mark assertion methods

--- a/src/contexts/__init__.py
+++ b/src/contexts/__init__.py
@@ -9,7 +9,7 @@ from .plugins.test_target_suppliers import ObjectSupplier
 __all__ = [
     'run', 'main', 'run_with_plugins',
     'catch', 'set_trace', 'time',
-    'context', 'spec', 'scenario', 'examples', 'setup', 'action', 'assertion', 'teardown'
+    'context', 'spec', 'scenario', 'method', 'examples', 'setup', 'action', 'assertion', 'teardown'
 ]
 
 

--- a/src/contexts/__init__.py
+++ b/src/contexts/__init__.py
@@ -2,14 +2,14 @@ import sys
 from . import core
 from .plugin_discovery import load_plugins
 from .tools import catch, set_trace, time
-from .plugins.identification.decorators import context, spec, scenario, method, examples, setup, action, assertion, teardown
+from .plugins.identification.decorators import context, spec, scenario, ignored, examples, setup, action, assertion, teardown
 from .plugins.test_target_suppliers import ObjectSupplier
 
 
 __all__ = [
     'run', 'main', 'run_with_plugins',
     'catch', 'set_trace', 'time',
-    'context', 'spec', 'scenario', 'method', 'examples', 'setup', 'action', 'assertion', 'teardown'
+    'context', 'spec', 'scenario', 'ignored', 'examples', 'setup', 'action', 'assertion', 'teardown'
 ]
 
 

--- a/src/contexts/__init__.py
+++ b/src/contexts/__init__.py
@@ -2,7 +2,7 @@ import sys
 from . import core
 from .plugin_discovery import load_plugins
 from .tools import catch, set_trace, time
-from .plugins.identification.decorators import context, spec, scenario, examples, setup, action, assertion, teardown
+from .plugins.identification.decorators import context, spec, scenario, method, examples, setup, action, assertion, teardown
 from .plugins.test_target_suppliers import ObjectSupplier
 
 

--- a/src/contexts/plugin_interface.py
+++ b/src/contexts/plugin_interface.py
@@ -208,7 +208,7 @@ class PluginInterface(object):
         :param func: The unbound method (or bound classmethod) which the test runner wants to be identified
 
         This method should return one of:
-            * :const:`~contexts.plugin_interface.IGNORED` - plugin wishes the method to not be treated as a test discovery method
+            * :const:`~contexts.plugin_interface.IGNORED` - plugin wishes the method to be ignored by Contexts
             * :const:`~contexts.plugin_interface.EXAMPLES` - plugin wishes the method to be treated as an 'examples' method
             * :const:`~contexts.plugin_interface.SETUP` - plugin wishes the method to be treated as an 'establish' method
             * :const:`~contexts.plugin_interface.ACTION` - plugin wishes the method to be treated as a 'because'

--- a/src/contexts/plugin_interface.py
+++ b/src/contexts/plugin_interface.py
@@ -208,7 +208,7 @@ class PluginInterface(object):
         :param func: The unbound method (or bound classmethod) which the test runner wants to be identified
 
         This method should return one of:
-            * :const:`~contexts.plugin_interface.METHOD` - plugin wishes the method to not be treated as a test discovery method
+            * :const:`~contexts.plugin_interface.IGNORED` - plugin wishes the method to not be treated as a test discovery method
             * :const:`~contexts.plugin_interface.EXAMPLES` - plugin wishes the method to be treated as an 'examples' method
             * :const:`~contexts.plugin_interface.SETUP` - plugin wishes the method to be treated as an 'establish' method
             * :const:`~contexts.plugin_interface.ACTION` - plugin wishes the method to be treated as a 'because'
@@ -271,8 +271,8 @@ TEST_FOLDER = type("_TestFolder", (), {})()
 TEST_FILE = type("_TestFile", (), {})()
 #: Returned by plugins to indicate that a class is a test class.
 CONTEXT = type("_Context", (), {})()
-#: Returned by plugins to indicate that a method is not a test discovery method.
-METHOD = type("_Methods", (), {})()
+#: Returned by plugins to indicate that a method is ignored by Contexts.
+IGNORED = type("_Ignored", (), {})()
 #: Returned by plugins to indicate that a method is an Examples method.
 EXAMPLES = type("_Examples", (), {})()
 #: Returned by plugins to indicate that a method is a setup method.

--- a/src/contexts/plugin_interface.py
+++ b/src/contexts/plugin_interface.py
@@ -208,6 +208,7 @@ class PluginInterface(object):
         :param func: The unbound method (or bound classmethod) which the test runner wants to be identified
 
         This method should return one of:
+            * :const:`~contexts.plugin_interface.METHOD` - plugin wishes the method to not be treated as a test discovery method
             * :const:`~contexts.plugin_interface.EXAMPLES` - plugin wishes the method to be treated as an 'examples' method
             * :const:`~contexts.plugin_interface.SETUP` - plugin wishes the method to be treated as an 'establish' method
             * :const:`~contexts.plugin_interface.ACTION` - plugin wishes the method to be treated as a 'because'
@@ -270,6 +271,8 @@ TEST_FOLDER = type("_TestFolder", (), {})()
 TEST_FILE = type("_TestFile", (), {})()
 #: Returned by plugins to indicate that a class is a test class.
 CONTEXT = type("_Context", (), {})()
+#: Returned by plugins to indicate that a method is not a test discovery method.
+METHOD = type("_Methods", (), {})()
 #: Returned by plugins to indicate that a method is an Examples method.
 EXAMPLES = type("_Examples", (), {})()
 #: Returned by plugins to indicate that a method is a setup method.

--- a/src/contexts/plugins/identification/decorators.py
+++ b/src/contexts/plugins/identification/decorators.py
@@ -1,6 +1,6 @@
 import types
 from contexts.plugin_interface import (
-    CONTEXT, METHOD, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
+    CONTEXT, IGNORED, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
 )
 from . import NameBasedIdentifier
 
@@ -8,7 +8,7 @@ from . import NameBasedIdentifier
 class DecoratorBasedIdentifier(object):
     decorated_items = {
         "contexts": set(),
-        "methods": set(),
+        "ignoreds": set(),
         "examples": set(),
         "setups": set(),
         "actions": set(),
@@ -33,8 +33,8 @@ class DecoratorBasedIdentifier(object):
             # this is to make it work with classmethods (such as examples)
             method = method.__func__
 
-        if method in self.decorated_items["methods"]:
-            return METHOD
+        if method in self.decorated_items["ignoreds"]:
+            return IGNORED
         if method in self.decorated_items["examples"]:
             return EXAMPLES
         if method in self.decorated_items["setups"]:
@@ -107,12 +107,12 @@ def examples(func):
     return func
 
 
-def method(func):
+def ignored(func):
     """
-    Decorator. Marks a method as not a test discovery method.
+    Decorator. Marks a method as ignored by Contexts.
     """
-    assert_not_multiple_decorators(func, "methods")
-    DecoratorBasedIdentifier.decorated_items["methods"].add(func)
+    assert_not_multiple_decorators(func, "ignoreds")
+    DecoratorBasedIdentifier.decorated_items["ignoreds"].add(func)
     return func
 
 

--- a/src/contexts/plugins/identification/decorators.py
+++ b/src/contexts/plugins/identification/decorators.py
@@ -1,11 +1,14 @@
 import types
-from contexts.plugin_interface import CONTEXT, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
+from contexts.plugin_interface import (
+    CONTEXT, METHOD, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
+)
 from . import NameBasedIdentifier
 
 
 class DecoratorBasedIdentifier(object):
     decorated_items = {
         "contexts": set(),
+        "methods": set(),
         "examples": set(),
         "setups": set(),
         "actions": set(),
@@ -30,6 +33,8 @@ class DecoratorBasedIdentifier(object):
             # this is to make it work with classmethods (such as examples)
             method = method.__func__
 
+        if method in self.decorated_items["methods"]:
+            return METHOD
         if method in self.decorated_items["examples"]:
             return EXAMPLES
         if method in self.decorated_items["setups"]:
@@ -99,6 +104,15 @@ def examples(func):
     """
     assert_not_multiple_decorators(func, "examples")
     DecoratorBasedIdentifier.decorated_items["examples"].add(func)
+    return func
+
+
+def method(func):
+    """
+    Decorator. Marks a method as not a test discovery method.
+    """
+    assert_not_multiple_decorators(func, "methods")
+    DecoratorBasedIdentifier.decorated_items["methods"].add(func)
     return func
 
 

--- a/test/plugin_tests/identification_tests/decorator_tests.py
+++ b/test/plugin_tests/identification_tests/decorator_tests.py
@@ -1,6 +1,6 @@
-from contexts.plugin_interface import CONTEXT, METHOD, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
+from contexts.plugin_interface import CONTEXT, IGNORED, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
 from contexts.plugins.identification.decorators import DecoratorBasedIdentifier
-from contexts import catch, spec, context, method, examples, setup, action, assertion, teardown
+from contexts import catch, spec, context, ignored, examples, setup, action, assertion, teardown
 
 
 class WhenMarkingAClassAsASpec:
@@ -38,7 +38,7 @@ class WhenMarkingAClassAsAContext:
 class WhenMarkingAMethodAsMethods:
     def context(self):
         class C:
-            @method
+            @ignored
             def it_should_do_things(self):
                 pass
         self.method = C.it_should_do_things
@@ -48,8 +48,8 @@ class WhenMarkingAMethodAsMethods:
         self.result = self.identifier.identify_method(self.method)
 
     @assertion
-    def it_should_identify_it_as_examples(self):
-        assert self.result is METHOD
+    def it_should_identify_it_as_ignored(self):
+        assert self.result is IGNORED
 
 
 class WhenMarkingAMethodAsExamples:

--- a/test/plugin_tests/identification_tests/decorator_tests.py
+++ b/test/plugin_tests/identification_tests/decorator_tests.py
@@ -1,6 +1,6 @@
-from contexts.plugin_interface import CONTEXT, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
-from contexts.plugins.identification.decorators import DecoratorBasedIdentifier, spec, context, examples, setup, action, assertion, teardown
-from contexts import catch
+from contexts.plugin_interface import CONTEXT, METHOD, EXAMPLES, SETUP, ACTION, ASSERTION, TEARDOWN
+from contexts.plugins.identification.decorators import DecoratorBasedIdentifier
+from contexts import catch, spec, context, method, examples, setup, action, assertion, teardown
 
 
 class WhenMarkingAClassAsASpec:
@@ -33,6 +33,23 @@ class WhenMarkingAClassAsAContext:
     @assertion
     def it_should_identify_it_as_a_context(self):
         assert self.result is CONTEXT
+
+
+class WhenMarkingAMethodAsMethods:
+    def context(self):
+        class C:
+            @method
+            def it_should_do_things(self):
+                pass
+        self.method = C.it_should_do_things
+        self.identifier = DecoratorBasedIdentifier()
+
+    def because_the_framework_asks_the_plugin_to_identify_the_method(self):
+        self.result = self.identifier.identify_method(self.method)
+
+    @assertion
+    def it_should_identify_it_as_examples(self):
+        assert self.result is METHOD
 
 
 class WhenMarkingAMethodAsExamples:

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,6 @@ envlist = py36,py37,flake8,coverage
 [testenv]
 commands = run-contexts
 
-[testenv:flake8]
-skip_install = true
-deps = flake8
-commands = flake8 src test setup.py tests
-
 [testenv:coverage]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py36,py37,flake8,coverage
+envlist = py36,py37,coverage
 
 [testenv]
 commands = run-contexts
@@ -22,8 +22,3 @@ commands = make html
 
 [pytest]
 addopts = --tb=short
-
-[flake8]
-# ignore = E261,E262,E265,E302,W391,E303,E266,E402,E731
-ignore=E501,E731
-max-line-length = 99


### PR DESCRIPTION
    Allow marking methods as NOT involved in test discovery
    
    i.e. not an examples method, not an assertion method, etc. etc.
    
    Example (with_context_manager is just a regular method and is ignored by
    contexts except to record that fact -- in particular it is not treated as a
    setup method despite the word "context" appearing in the method name):
    
        from contexts import method
    
        class When_whatever:
    
            @method
            def with_context_manager(self):
                ...
    
            def should_whatever(self):
                ...